### PR TITLE
feat: Add initial working config for localfiles server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ wheels/
 MANIFEST
 
 # Virtual Environment
+.venv/
 venv/
 env/
 ENV/
@@ -36,7 +37,7 @@ ENV/
 .env
 
 # MCP specific
-config/config.json
+# config/config.json
 
 # Logs
 *.log

--- a/config/config.json
+++ b/config/config.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "localfiles": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "."],
+      "env": {}
+    }
+  }
+}


### PR DESCRIPTION
Manually created config.json as a workaround for 'mcp add' CLI issues. This config enables testing with the @modelcontextprotocol/server-filesystem.